### PR TITLE
Use underlying type in default case in CompletionCode stringer

### DIFF
--- a/command.go
+++ b/command.go
@@ -91,7 +91,7 @@ func (c CompletionCode) String() string {
 	case CompletionIllegalCommandDisabled:
 		return "Command sub-function has been disabled or is unavailable"
 	default:
-		return fmt.Sprintf("0x%02x", c)
+		return fmt.Sprintf("0x%02x", uint8(c))
 	}
 }
 


### PR DESCRIPTION
Not using the underlying type results in a stack overflow, as fmt.Sprintf will call the type's stringer regardless of formatting options. Use the underlying uint8 type instead.